### PR TITLE
Adding retry delay when there is a ConnectException

### DIFF
--- a/src/main/java/vizceral/hystrix/HystrixReader.java
+++ b/src/main/java/vizceral/hystrix/HystrixReader.java
@@ -121,15 +121,10 @@ public class HystrixReader
                 .filter(c -> c != null)
                 .onErrorResumeNext(ex ->
                 {
-                    if (ex instanceof ConnectException) {
-                        try {
-                            TimeUnit.SECONDS.sleep(10);
-                        } catch (Exception ignore) { };
-                    }
                     if (!(ex instanceof UnknownClusterException || ex instanceof IllegalStateException))
                     {
-                        logger.error("Exception from hystrix event for cluster " + cluster + " for region " + configuration.getRegionName() + ". Will retry", ex);
-                        return read();
+                        logger.error("Exception from hystrix event for cluster " + cluster + " for region " + configuration.getRegionName() + ". Will retry in 10 seconds", ex);
+                        return Observable.timer(10, TimeUnit.SECONDS).flatMap(ignore -> read());
                     }
                     return Observable.error(ex);
                 });

--- a/src/main/java/vizceral/hystrix/HystrixReader.java
+++ b/src/main/java/vizceral/hystrix/HystrixReader.java
@@ -16,8 +16,10 @@ import io.reactivex.netty.protocol.http.sse.ServerSentEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
+import java.util.concurrent.TimeUnit;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -119,6 +121,11 @@ public class HystrixReader
                 .filter(c -> c != null)
                 .onErrorResumeNext(ex ->
                 {
+                    if (ex instanceof ConnectException) {
+                        try {
+                            TimeUnit.SECONDS.sleep(10);
+                        } catch (Exception ignore) { };
+                    }
                     if (!(ex instanceof UnknownClusterException || ex instanceof IllegalStateException))
                     {
                         logger.error("Exception from hystrix event for cluster " + cluster + " for region " + configuration.getRegionName() + ". Will retry", ex);


### PR DESCRIPTION
Turbine may not be ready for connections when vizceral-hystrix has started.
